### PR TITLE
Fix incorrect gemfile pins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'ruby-termios', '0.1.1'
-gem 'ruby-terminfo', '1.0.2'
+gem 'ruby-termios', '1.0.2'
+gem 'ruby-terminfo', '0.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ruby-terminfo
-  ruby-termios
+  ruby-terminfo (= 0.1.1)
+  ruby-termios (= 1.0.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
I was getting the error Could not find gem 'ruby-termios (= 0.1.1)' in
any of the gem sources listed in your Gemfile when trying to bundle and
use this gem. Seems like the gems were pinned to the wrong versions.